### PR TITLE
Creating kind cluster

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -85,7 +85,7 @@ func createKindCluster() error {
 
 	clusterWait := exec.Command("kubectl", "wait", "pod", "--timeout=-1s", "--for=condition=Ready", "-l", "!job-name", "-n", "kube-system")
 	if err := clusterWait.Run(); err != nil {
-		fmt.Errorf("wait: %w", err)
+		return fmt.Errorf("wait: %w", err)
 	}
 
 	fmt.Println("Cluster created")

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -71,7 +71,8 @@ func createKindCluster() error {
 		return fmt.Errorf("kind create: %w", err)
 	}
 
-	createCluster := exec.Command("kind", "create", "cluster", "--config", kindConfig.Name())
+	configFile := kindConfig.Name()
+	createCluster := exec.Command("kind", "create", "cluster", "--config", configFile)
 	if err := createCluster.Run(); err != nil {
 		return fmt.Errorf("kind create: %w", err)
 	}


### PR DESCRIPTION
Fixes #10 

# Changes

- Implements a method to create a new Kind cluster as part of the quickstart plugin

/kind enhancement

**Release Note**

```release-note
Create a new Kind cluster as part of the quickstart plugin
```
