### PR TITLE
Adding kourier-ingress.yaml to repo

### DIFF
--- a/config/kourier-ingress.yaml
+++ b/config/kourier-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-ingress
+  namespace: kourier-system
+  labels:
+    networking.knative.dev/ingress-provider: kourier
+spec:
+  type: NodePort
+  selector:
+    app: 3scale-kourier-gateway
+  ports:
+    - name: http2
+      nodePort: 31080
+      port: 80
+      targetPort: 8080


### PR DESCRIPTION
This PR moves the kourier-ingress.yaml from a gist into the repo proper. Once the yaml is in the repo, we can submit a fix for #14 so that the plugin can pull from this repo rather than the gist.