### PR TITLE
Create example broker

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -183,6 +183,20 @@ func Eventing() error {
 	}
 	fmt.Println("    Mt-channel broker installed...")
 
+	config := `apiVersion: eventing.knative.dev/v1
+kind: broker
+metadata:
+ name: example-broker
+ namespace: default`
+
+	exampleBroker := exec.Command("kubectl", "apply", "-f", "-")
+	exampleBroker.Stdin = strings.NewReader(config)
+	if err := runCommand(exampleBroker); err != nil {
+		return fmt.Errorf("example broker: %w", err)
+	}
+
+	fmt.Println("    Example broker installed...")
+
 	return nil
 }
 


### PR DESCRIPTION
# Changes

:bug: Quickstart did not create the example broker, which meant that the serving examples would not work. This PR create the example broker.

/kind bug

