### PR TITLE
Replace manual wait with kind internal wait

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -145,18 +145,10 @@ func createNewCluster() error {
 		"    listenAddress: 127.0.0.1\n" +
 		"    hostPort: 80"
 
-	createCluster := exec.Command("kind", "create", "cluster", "--config=-")
+	createCluster := exec.Command("kind", "create", "cluster", "--wait=120s", "--config=-")
 	createCluster.Stdin = strings.NewReader(config)
 	if err := runCommand(createCluster); err != nil {
 		return fmt.Errorf("kind create: %w", err)
-	}
-
-	// sleep for 10s to allow initial cluster creation, then wait until all pods in kube-system namespace are ready
-	fmt.Println("    Waiting on cluster to be ready...")
-	time.Sleep(10 * time.Second)
-	clusterWait := exec.Command("kubectl", "wait", "pod", "--timeout=-1s", "--for=condition=Ready", "-l", "!job-name", "-n", "kube-system")
-	if err := runCommand(clusterWait); err != nil {
-		return fmt.Errorf("kind ready: %w", err)
 	}
 
 	fmt.Println("    Cluster ready")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

`kind create cluster` has a `--wait` flag, which can be used to wait for the control-plane node to be ready, which should cover the use-case of everything we're trying to make sure with our manual waits. See https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster for docs.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind cleanup

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Remove arbitrary 10s sleep after cluster creation.
```

/assign @psschwei @csantanapr 