### PR TITLE
Updating install location to PATH instead of plugin directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are two ways to run `kn quickstart`:
 1. You can run it standalone, just put it on your system path and make sure it is executable.
 2. You can install it as a plugin of the `kn` client to run:
     * Follow the [documentation](https://github.com/knative/client/blob/main/docs/README.md#installing-kn) to install `kn client` if you don't have it
-    * Copy the `kn-quickstart` binary to the `~/.config/kn/plugins/` directory and make sure its filename is `kn-quickstart`
+    * Copy the `kn-quickstart` binary to a directory on your `PATH` (for example, `/usr/local/bin`) and make sure its filename is `kn-quickstart`
     * Run `kn plugin list` to verify that the `kn-quickstart` plugin is installed successfully
 
 After the plugin is installed, you can use `kn quickstart` to run its related subcommands.


### PR DESCRIPTION
Updating README to use PATH as install location (instead of plugin location). 
