### PR TITLE
Ignore releasabilty job until on release train

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 kn-quickstart*
+
+# ignore releasabilty job until on release train
+.github/workflows/knative-releasability.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Add releasability job to `.gitignore`, to prevent automatic PRs trying to add it to the repo

(see prior discussion in #102 )

/assign @csantanapr @julz 