### PR TITLE
Adding check that docker is running

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -55,6 +55,9 @@ func SetUp() error {
 
 func createKindCluster() error {
 
+	if err := checkDocker(); err != nil {
+		return fmt.Errorf("%w", err)
+	}
 	fmt.Println("✅ Checking dependencies...")
 	if err := checkKindVersion(); err != nil {
 		return fmt.Errorf("kind version: %w", err)
@@ -63,6 +66,15 @@ func createKindCluster() error {
 		return fmt.Errorf("existing cluster: %w", err)
 	}
 
+	return nil
+}
+
+// checkDocker checks that Docker is running on the users local system.
+func checkDocker() error {
+	dockerCheck := exec.Command("docker", "stats", "--no-stream")
+	if err := dockerCheck.Run(); err != nil {
+		return fmt.Errorf("docker not running")
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Adds a check to see if docker is running before trying to start quickstart on kind

/kind enhancement

Part of a fix for issues raised in #124 

**Release Note**

```release-note
Adds a check to see if docker is running before trying to start quickstart on kind
```

/assign @julz @csantanapr 