### PR TITLE
Show users cluster creation details

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -166,11 +166,20 @@ nodes:
 
 	createCluster := exec.Command("kind", "create", "cluster", "--wait=120s", "--config=-")
 	createCluster.Stdin = strings.NewReader(config)
-	if err := runCommand(createCluster); err != nil {
+	if err := runCommandWithOutput(createCluster); err != nil {
 		return fmt.Errorf("kind create: %w", err)
 	}
 
-	fmt.Println("    Cluster ready")
+	return nil
+}
+
+func runCommandWithOutput(c *exec.Cmd) error {
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("piping output: %w", err)
+	}
+	fmt.Print("\n")
 	return nil
 }
 

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -148,11 +148,11 @@ func createNewCluster() error {
 	fmt.Println("☸ Creating Minikube cluster...")
 	fmt.Println("\nBy default, using the standard minikube driver for your system")
 	fmt.Println("If you wish to use a different driver, please configure minikube using")
-	fmt.Println("    minikube config set driver <your-driver>")
+	fmt.Print("    minikube config set driver <your-driver>\n\n")
 
 	// create cluster and wait until ready
 	createCluster := exec.Command("minikube", "start", "--cpus", "3", "--profile", clusterName, "--wait", "all")
-	if err := runCommand(createCluster); err != nil {
+	if err := runCommandWithOutput(createCluster); err != nil {
 		return fmt.Errorf("minikube create: %w", err)
 	}
 
@@ -163,7 +163,16 @@ func createNewCluster() error {
 	}
 	fmt.Println("    Minikube tunnel...")
 
-	fmt.Println("    Cluster ready")
+	return nil
+}
+
+func runCommandWithOutput(c *exec.Cmd) error {
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("piping output: %w", err)
+	}
+	fmt.Print("\n")
 	return nil
 }
 


### PR DESCRIPTION
# Changes

- :gift: When running quickstart, show users the cluster creation output from minikube or kind 

/kind enhancement

Fixes #127 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

```release-note
Users will see the cluster creation info from kind/minikube while quickstart is running
```

/assign @csantanapr