### PR TITLE
Remove duplicate minikube tunnel 

### DIFF
--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -156,13 +156,6 @@ func createNewCluster() error {
 		return fmt.Errorf("minikube create: %w", err)
 	}
 
-	// minikube tunnel
-	tunnel := exec.Command("minikube", "tunnel", "--profile", "minikube-knative")
-	if err := tunnel.Start(); err != nil {
-		return fmt.Errorf("tunnel: %w", err)
-	}
-	fmt.Println("    Minikube tunnel...")
-
 	return nil
 }
 


### PR DESCRIPTION
# Changes

- :bug: remove duplicate call to minikube tunnel (now only called when setting up kourier networking)

/kind bug

Fixes #111 

/assign @csantanapr 