### PR TITLE
Manual minikube tunnel command for windows/mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Set up a local Knative cluster using [Minikube](https://minikube.sigs.k8s.io/):
 kn quickstart minikube
 ```
 
+Note: for Windows/Mac users, after the above command completes, you will need to run the following in a separate terminal window:
+
+``` bash
+minikube tunnel --profile minikube-knative
+```
+
 ## Building from Source
 
 You must [set up your development environment](https://github.com/knative/client/blob/master/docs/DEVELOPMENT.md#prerequisites) before you build `kn-plugin-quickstart`.

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -17,6 +17,7 @@ package install
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -103,11 +104,17 @@ func KourierMinikube() error {
 
 	fmt.Println("    Domain DNS set up...")
 
-	tunnel := exec.Command("minikube", "tunnel", "--profile", "minikube-knative")
-	if err := tunnel.Start(); err != nil {
-		return fmt.Errorf("tunnel: %w", err)
+	// For windows and mac users, do not automatically spawn a tunnel
+	// Instead, they will be directed to create one manually after
+	// the plugin finishes
+	if runtime.GOOS != "window" && runtime.GOOS != "darwin" {
+		tunnel := exec.Command("minikube", "tunnel", "--profile", "minikube-knative")
+		if err := tunnel.Start(); err != nil {
+			return fmt.Errorf("tunnel: %w", err)
+		}
+		fmt.Println("    Minikube tunnel...")
 	}
-	fmt.Println("    Minikube tunnel...")
+
 	fmt.Println("    Finished configuring Kourier")
 	return nil
 }

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -34,10 +34,6 @@ var minikubeVersion = 1.23
 func SetUp() error {
 	start := time.Now()
 
-	if runtime.GOOS == "darwin" {
-		fmt.Println("NOTE: Using Minikube on Mac may require entering your password to enable networking.")
-	}
-
 	if err := createMinikubeCluster(); err != nil {
 		return fmt.Errorf("creating cluster: %w", err)
 	}
@@ -53,9 +49,17 @@ func SetUp() error {
 	if err := install.Eventing(); err != nil {
 		return fmt.Errorf("install eventing: %w", err)
 	}
+
 	finish := time.Since(start).Round(time.Second)
 	fmt.Printf("🚀 Knative install took: %s \n", finish)
 	fmt.Println("🎉 Now have some fun with Serverless and Event Driven Apps!")
+
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		fmt.Print("\n")
+		fmt.Println("To finish setting up networking for minikube, run the following command in a separate terminal window:")
+		fmt.Println("    minikube tunnel --profile minikube-knative")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :broom: Fixes issue with `minikube tunnel` for Mac/Windows users by having users run the tunnel in a separate terminal window after the plugin finishes

/kind cleanup

[Slack discussion of issue](https://knative.slack.com/archives/C01JBD1LSF3/p1634674328090600?thread_ts=1634648402.083200&cid=C01JBD1LSF3)

/assign @csantanapr 