### PR TITLE
Use sslip.io for domain

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -81,7 +81,7 @@ spec:
 
 	fmt.Println("    Kourier service installed...")
 
-	domainDns := exec.Command("kubectl", "patch", "configmap", "-n", "knative-serving", "config-domain", "-p", "{\"data\": {\"127.0.0.1.nip.io\": \"\"}}")
+	domainDns := exec.Command("kubectl", "patch", "configmap", "-n", "knative-serving", "config-domain", "-p", "{\"data\": {\"127.0.0.1.sslip.io\": \"\"}}")
 	if err := domainDns.Run(); err != nil {
 		return fmt.Errorf("domain dns: %w", err)
 	}


### PR DESCRIPTION
# Changes
- :broom: Swap DNS from nip to sslip. Consistent with [Configure DNS](https://knative.dev/docs/install/serving/install-serving-with-yaml/#configure-dns) on Knative

/kind cleanup

**Release Note**
```release-note
Set default domain to sslip.io as mentioned in [Configure DNS](https://knative.dev/docs/install/serving/install-serving-with-yaml/#configure-dns) on Knative.dev
```

