### PR TITLE
Add cluster name option to kind and minikubec commands

### DIFF
--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -17,23 +17,17 @@ package command
 import (
 	"fmt"
 
-	"knative.dev/kn-plugin-quickstart/pkg/minikube"
-
 	"github.com/spf13/cobra"
 )
 
-// NewMinikubeCommand implements 'kn quickstart minikube' command
-func NewMinikubeCommand() *cobra.Command {
+var name string
 
-	var minikubeCmd = &cobra.Command{
-		Use:   "minikube",
-		Short: "Quickstart with Minikube",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("Running Knative Quickstart using Minikube")
-			return minikube.SetUp(name)
-		},
-	}
-	// Set minikubeCmd options
-	clusterNameOption(minikubeCmd, "knative", "minikube")
-	return minikubeCmd
+func clusterNameOption(targetCmd *cobra.Command, flagDefault, commandName string) {
+	targetCmd.Flags().StringVarP(
+		&name,
+		"name",
+		"n",
+		flagDefault,
+		fmt.Sprintf("%s cluster name to be used by kn-quickstart (default %s)", commandName, flagDefault),
+	)
 }

--- a/internal/command/kind.go
+++ b/internal/command/kind.go
@@ -21,8 +21,6 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/kind"
 )
 
-var kindClusterName string
-
 // NewKindCommand implements 'kn quickstart kind' command
 func NewKindCommand() *cobra.Command {
 	var kindCmd = &cobra.Command{
@@ -30,15 +28,11 @@ func NewKindCommand() *cobra.Command {
 		Short: "Quickstart with Kind",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Kind")
-			return kind.SetUp(kindClusterName)
+			return kind.SetUp(name)
 		},
 	}
 	// Set kindCmd options
-	kindOptions(kindCmd)
+	clusterNameOption(kindCmd, "knative", "kind")
 
 	return kindCmd
-}
-
-func kindOptions(targetCmd *cobra.Command) {
-	targetCmd.Flags().StringVarP(&kindClusterName, "name", "n", "", "kind cluster name to be used by kn-quickstart, config (default kind)")
 }

--- a/internal/command/kind.go
+++ b/internal/command/kind.go
@@ -21,14 +21,24 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/kind"
 )
 
+var kindClusterName string
+
 // NewKindCommand implements 'kn quickstart kind' command
 func NewKindCommand() *cobra.Command {
-	return &cobra.Command{
+	var kindCmd = &cobra.Command{
 		Use:   "kind",
 		Short: "Quickstart with Kind",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Kind")
-			return kind.SetUp()
+			return kind.SetUp(kindClusterName)
 		},
 	}
+	// Set kindCmd options
+	kindOptions(kindCmd)
+
+	return kindCmd
+}
+
+func kindOptions(targetCmd *cobra.Command) {
+	targetCmd.Flags().StringVarP(&kindClusterName, "name", "n", "", "kind cluster name to be used by kn-quickstart, config (default kind)")
 }

--- a/internal/command/minikube.go
+++ b/internal/command/minikube.go
@@ -22,14 +22,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var miniKClusterName string
+
 // NewMinikubeCommand implements 'kn quickstart minikube' command
 func NewMinikubeCommand() *cobra.Command {
-	return &cobra.Command{
+
+	var minikubeCmd = &cobra.Command{
 		Use:   "minikube",
 		Short: "Quickstart with Minikube",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Minikube")
-			return minikube.SetUp()
+			return minikube.SetUp(miniKClusterName)
 		},
 	}
+	// Set minikubeCmd options
+	minikubeOptions(minikubeCmd)
+	return minikubeCmd
+}
+
+func minikubeOptions(targetCmd *cobra.Command) {
+	targetCmd.Flags().StringVarP(&miniKClusterName, "name", "n", "", "minikube cluster name to be used by kn-quickstart, config (default kind)")
 }

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -21,7 +21,6 @@ import (
 
 // NewRootCommand represents the plugin's entrypoint
 func NewRootCommand() *cobra.Command {
-
 	var rootCmd = &cobra.Command{
 		Use:   "kn-quickstart",
 		Short: "Get started quickly with Knative",

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -31,7 +31,9 @@ var clusterName = "knative"
 var kindVersion = 0.11
 
 // SetUp creates a local Kind cluster and installs all the relevant Knative components
-func SetUp() error {
+func SetUp(name string) error {
+	clusterName = name
+
 	start := time.Now()
 	if err := createKindCluster(); err != nil {
 		return fmt.Errorf("creating cluster: %w", err)
@@ -120,7 +122,7 @@ func checkForExistingCluster() error {
 		return fmt.Errorf("check cluster: %w", err)
 	}
 	// TODO Add tests for regex
-	r := regexp.MustCompile(`(?m)^knative\n`)
+	r := regexp.MustCompile(fmt.Sprintf(`(?m)^%s\n`, clusterName))
 	matches := r.Match(out)
 	if matches {
 		var resp string

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -27,14 +27,14 @@ import (
 )
 
 var kubernetesVersion = "v1.22.2@sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f"
-var clusterName = "knative"
+var clusterName string
 var kindVersion = 0.11
 
 // SetUp creates a local Kind cluster and installs all the relevant Knative components
 func SetUp(name string) error {
+	start := time.Now()
 	clusterName = name
 
-	start := time.Now()
 	if err := createKindCluster(); err != nil {
 		return fmt.Errorf("creating cluster: %w", err)
 	}

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -32,8 +32,9 @@ var kubernetesVersion = "1.22.2"
 var minikubeVersion = 1.23
 
 // SetUp creates a local Minikube cluster and installs all the relevant Knative components
-func SetUp() error {
+func SetUp(name string) error {
 	start := time.Now()
+	clusterName = name
 
 	if err := createMinikubeCluster(); err != nil {
 		return fmt.Errorf("creating cluster: %w", err)

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -27,7 +27,7 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
-var clusterName = "minikube-knative"
+var clusterName string
 var kubernetesVersion = "1.22.2"
 var minikubeVersion = 1.23
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🎁 Added --name, -n flag to be used on the kind and minikube commands

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #166

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Now you can set the cluster name when using the kind or minikube command
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
