### PR TITLE
Pause for minikube tunnel setup on mac/windows

### DIFF
--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -39,6 +39,13 @@ func SetUp(name string) error {
 	if err := createMinikubeCluster(); err != nil {
 		return fmt.Errorf("creating cluster: %w", err)
 	}
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		fmt.Print("\n")
+		fmt.Println("To finish setting up networking for minikube, run the following command in a separate terminal window:")
+		fmt.Println("    minikube tunnel --profile minikube-knative")
+		fmt.Println("\nPress the Enter key to continue")
+		fmt.Scanln()
+	}
 	if err := install.Serving(); err != nil {
 		return fmt.Errorf("install serving: %w", err)
 	}
@@ -55,12 +62,6 @@ func SetUp(name string) error {
 	finish := time.Since(start).Round(time.Second)
 	fmt.Printf("🚀 Knative install took: %s \n", finish)
 	fmt.Println("🎉 Now have some fun with Serverless and Event Driven Apps!")
-
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-		fmt.Print("\n")
-		fmt.Println("To finish setting up networking for minikube, run the following command in a separate terminal window:")
-		fmt.Println("    minikube tunnel --profile minikube-knative")
-	}
 
 	return nil
 }


### PR DESCRIPTION
# Changes

For Windows/Mac users, when installing on Minikube adds a pause for users to run the `minikube tunnel` command before continuing. This will alleviate an issue with domain setup (which needs the tunnel in place to continue).

```release-note
Pauses for Windows/Mac users to set up Minikube tunnel before proceeding with the Knative installation
```

/assign @csantanapr 