### PR TITLE
Update K8s version, provide multi-arch support for kind

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
-var kubernetesVersion = "v1.22.2@sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f"
+var kubernetesVersion = "v1.22.4"
 var clusterName string
 var kindVersion = 0.11
 

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -28,7 +28,7 @@ import (
 )
 
 var clusterName string
-var kubernetesVersion = "1.22.2"
+var kubernetesVersion = "1.22.4"
 var minikubeVersion = 1.23
 
 // SetUp creates a local Minikube cluster and installs all the relevant Knative components


### PR DESCRIPTION
# Changes

Updates to Kubernetes version 1.22.4, and removes the SHA value for the Kind image to allow the local system to pull either the appropriate image for the user's architecture.

Fixes #181 

**Release Note**

```release-note
Bumps Kubernetes version to 1.22.4
Provides kind support for arm architecture
```

/assign @csantanapr 