### PR TITLE
Fix some stray references to minikube-knative profile

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -108,7 +108,7 @@ func KourierMinikube() error {
 	// Instead, they will be directed to create one manually after
 	// the plugin finishes
 	if runtime.GOOS != "window" && runtime.GOOS != "darwin" {
-		tunnel := exec.Command("minikube", "tunnel", "--profile", "minikube-knative")
+		tunnel := exec.Command("minikube", "tunnel", "--profile", "knative")
 		if err := tunnel.Start(); err != nil {
 			return fmt.Errorf("tunnel: %w", err)
 		}

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -42,7 +42,7 @@ func SetUp(name string) error {
 	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		fmt.Print("\n")
 		fmt.Println("To finish setting up networking for minikube, run the following command in a separate terminal window:")
-		fmt.Println("    minikube tunnel --profile minikube-knative")
+		fmt.Println("    minikube tunnel --profile knative")
 		fmt.Println("\nPress the Enter key to continue")
 		fmt.Scanln()
 	}
@@ -109,7 +109,6 @@ func checkMinikubeVersion() error {
 // the option of deleting the existing cluster and recreating it. If not, it proceeds to
 // creating a new cluster
 func checkForExistingCluster() error {
-
 	getClusters := exec.Command("minikube", "profile", "list")
 	out, err := getClusters.CombinedOutput()
 	if err != nil {
@@ -151,7 +150,6 @@ func checkForExistingCluster() error {
 
 // createNewCluster creates a new Minikube cluster
 func createNewCluster() error {
-
 	fmt.Println("☸ Creating Minikube cluster...")
 	fmt.Println("\nBy default, using the standard minikube driver for your system")
 	fmt.Println("If you wish to use a different driver, please configure minikube using")


### PR DESCRIPTION
# Changes

We renamed the minikube profile to `knative` a while back, and this PR cleans up a few stray references that used the older profile name (`minikube-knative`).

/assign @csantanapr 