### PR TITLE
Add instruction to keep minikube tunnel terminal open

### DIFF
--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -43,6 +43,7 @@ func SetUp(name string) error {
 		fmt.Print("\n")
 		fmt.Println("To finish setting up networking for minikube, run the following command in a separate terminal window:")
 		fmt.Println("    minikube tunnel --profile knative")
+		fmt.Println("The tunnel window must remain open until you are done with the quickstart environment.")
 		fmt.Println("\nPress the Enter key to continue")
 		fmt.Scanln()
 	}


### PR DESCRIPTION
# Changes

Adds note to keep tunnel window open while using quickstart. Fixes issue raised in https://github.com/knative/docs/issues/4547

/assign @csantanapr 