### PR TITLE
Use shared hack functions in build

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -349,6 +349,9 @@ if $(has_flag --debug); then
     set -x
 fi
 
+# Shared funcs from hack repo
+source $(basedir)/vendor/knative.dev/hack/library.sh
+
 # Shared funcs with CI
 source $(basedir)/hack/build-flags.sh
 


### PR DESCRIPTION
# Changes

Adds the shared hack functions to the build script

Fixes https://github.com/knative/hack/issues/132

cc @dprotaso @amandahla