### PR TITLE
clusterNameOption(): simplify interface

### DIFF
--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -22,12 +22,12 @@ import (
 
 var name string
 
-func clusterNameOption(targetCmd *cobra.Command, flagDefault, commandName string) {
+func clusterNameOption(targetCmd *cobra.Command, flagDefault string) {
 	targetCmd.Flags().StringVarP(
 		&name,
 		"name",
 		"n",
 		flagDefault,
-		fmt.Sprintf("%s cluster name to be used by kn-quickstart (default %s)", commandName, flagDefault),
+		fmt.Sprintf("%s cluster name to be used by kn-quickstart (default %s)", targetCmd.Name(), flagDefault),
 	)
 }

--- a/internal/command/kind.go
+++ b/internal/command/kind.go
@@ -32,7 +32,7 @@ func NewKindCommand() *cobra.Command {
 		},
 	}
 	// Set kindCmd options
-	clusterNameOption(kindCmd, "knative", "kind")
+	clusterNameOption(kindCmd, "knative")
 
 	return kindCmd
 }

--- a/internal/command/minikube.go
+++ b/internal/command/minikube.go
@@ -34,6 +34,6 @@ func NewMinikubeCommand() *cobra.Command {
 		},
 	}
 	// Set minikubeCmd options
-	clusterNameOption(minikubeCmd, "knative", "minikube")
+	clusterNameOption(minikubeCmd, "knative")
 	return minikubeCmd
 }


### PR DESCRIPTION
# Changes
- :broom: clusterNameOption(): simplify interface

/kind cleanup
