### PR TITLE
remove default duplicated in clusterNameOption flag

### DIFF
--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -28,6 +28,6 @@ func clusterNameOption(targetCmd *cobra.Command, flagDefault string) {
 		"name",
 		"n",
 		flagDefault,
-		fmt.Sprintf("%s cluster name to be used by kn-quickstart (default %s)", targetCmd.Name(), flagDefault),
+		fmt.Sprintf("%s cluster name to be used by kn-quickstart", targetCmd.Name()),
 	)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- remove default duplicated in clusterNameOption flag
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind 🧹 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Now the cluster name flag does not show a duplicated default message
```
