### PR TITLE
Updates to kubernetes v1.23 and minikube to v1.25

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
-var kubernetesVersion = "v1.22.4"
+var kubernetesVersion = "v1.23.3"
 var clusterName string
 var kindVersion = 0.11
 

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -28,8 +28,8 @@ import (
 )
 
 var clusterName string
-var kubernetesVersion = "1.23.3"
-var minikubeVersion = 1.23
+var kubernetesVersion = "1.23.4"
+var minikubeVersion = 1.25
 
 // SetUp creates a local Minikube cluster and installs all the relevant Knative components
 func SetUp(name string) error {


### PR DESCRIPTION
# Changes

- Updates minikube k8s to v1.23.4 (latest available version)
- Updates kind k8s to v1.23.3 (latest available version of kindest/node image)
- Updates recommended minimum version of minikube to v1.25

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Updates Kubernetes to v1.23 and recommended Minikube to v1.25
```

