### PR TITLE
Adds a command line flag to set k8s version

### DIFF
--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -39,5 +39,5 @@ func kubernetesVersionOption(targetCmd *cobra.Command, flagDefault string) {
 		"kubernetes-version",
 		"k",
 		flagDefault,
-		fmt.Sprintf("kubernetes version to use (1.x.y)"))
+		fmt.Sprint("kubernetes version to use (1.x.y)"))
 }

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -39,5 +39,5 @@ func kubernetesVersionOption(targetCmd *cobra.Command, flagDefault string) {
 		"kubernetes-version",
 		"k",
 		flagDefault,
-		fmt.Sprint("kubernetes version to use (1.x.y)"))
+		"kubernetes version to use (1.x.y)")
 }

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -21,6 +21,7 @@ import (
 )
 
 var name string
+var kubernetesVersion string
 
 func clusterNameOption(targetCmd *cobra.Command, flagDefault string) {
 	targetCmd.Flags().StringVarP(
@@ -30,4 +31,13 @@ func clusterNameOption(targetCmd *cobra.Command, flagDefault string) {
 		flagDefault,
 		fmt.Sprintf("%s cluster name to be used by kn-quickstart", targetCmd.Name()),
 	)
+}
+
+func kubernetesVersionOption(targetCmd *cobra.Command, flagDefault string) {
+	targetCmd.Flags().StringVarP(
+		&kubernetesVersion,
+		"kubernetes-version",
+		"k",
+		flagDefault,
+		fmt.Sprintf("kubernetes version to use (1.x.y)"))
 }

--- a/internal/command/kind.go
+++ b/internal/command/kind.go
@@ -28,11 +28,12 @@ func NewKindCommand() *cobra.Command {
 		Short: "Quickstart with Kind",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Kind")
-			return kind.SetUp(name)
+			return kind.SetUp(name, kubernetesVersion)
 		},
 	}
 	// Set kindCmd options
 	clusterNameOption(kindCmd, "knative")
+	kubernetesVersionOption(kindCmd, "")
 
 	return kindCmd
 }

--- a/internal/command/minikube.go
+++ b/internal/command/minikube.go
@@ -30,10 +30,11 @@ func NewMinikubeCommand() *cobra.Command {
 		Short: "Quickstart with Minikube",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Minikube")
-			return minikube.SetUp(name)
+			return minikube.SetUp(name, kubernetesVersion)
 		},
 	}
 	// Set minikubeCmd options
 	clusterNameOption(minikubeCmd, "knative")
+	kubernetesVersionOption(minikubeCmd, "")
 	return minikubeCmd
 }

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -31,9 +31,12 @@ var clusterName string
 var kindVersion = 0.11
 
 // SetUp creates a local Kind cluster and installs all the relevant Knative components
-func SetUp(name string) error {
+func SetUp(name, kVersion string) error {
 	start := time.Now()
 	clusterName = name
+	if kVersion != "" {
+		kubernetesVersion = "v" + kVersion
+	}
 
 	if err := createKindCluster(); err != nil {
 		return fmt.Errorf("creating cluster: %w", err)


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

# Changes

Allows users to set the k8s version using a command line flag. Validation of the version is done by kind/minikube, so quickstart won't check to see if that version of k8s actually exists for the specified runtime.

In the case of Kind, it will only use official images (i.e. `kindest/node:<version>`). Non-kindest/node images is handled in #196 

/kind enhancement

**Release Note**

```release-note
Users can specify the Kubernetes version via a command line argument, for example `--kubernetes-version 1.23.2`. 
```

