### PR TITLE
adds check for kubectl

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -33,6 +33,14 @@ var kindVersion = 0.11
 // SetUp creates a local Kind cluster and installs all the relevant Knative components
 func SetUp(name, kVersion string) error {
 	start := time.Now()
+
+	// kubectl is required, fail if not found
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		fmt.Println("ERROR: kubectl is required for quickstart")
+		fmt.Println("Download from https://kubectl.docs.kubernetes.io/installation/kubectl/")
+		os.Exit(1)
+	}
+
 	clusterName = name
 	if kVersion != "" {
 		if strings.Contains(kVersion, ":") {

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -35,6 +35,14 @@ var minikubeVersion = 1.25
 // SetUp creates a local Minikube cluster and installs all the relevant Knative components
 func SetUp(name, kVersion string) error {
 	start := time.Now()
+
+	// kubectl is required, fail if not found
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		fmt.Println("ERROR: kubectl is required for quickstart")
+		fmt.Println("Download from https://kubectl.docs.kubernetes.io/installation/kubectl/")
+		os.Exit(1)
+	}
+
 	clusterName = name
 	if kVersion != "" {
 		kubernetesVersion = kVersion


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Fixes #222 

<!-- Thanks for sending a pull request! -->


```release-note
Adds a step to check if `kubectl` is installed on the user's system. 
```

/assign @csantanapr 
