### PR TITLE
Update knative components to v1.4

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -22,9 +22,9 @@ import (
 	"time"
 )
 
-var servingVersion = "1.3.0"
-var kourierVersion = "1.3.0"
-var eventingVersion = "1.3.0"
+var servingVersion = "1.4.0"
+var kourierVersion = "1.4.0"
+var eventingVersion = "1.4.0"
 
 // Kourier installs Kourier networking layer from Github YAML files
 func Kourier() error {


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

**Release Note**

```release-note
Updates Knative version to 1.4
```

/assign @nader-ziada @ikvmw 
/hold
until after Serving/Eventing/Kourier releases are cut

