### PR TITLE
Add serving e2e test

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -1,0 +1,63 @@
+name: e2e
+
+on:
+  pull_request:
+    branches: [ 'main', 'release-*' ]
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for
+  # '*.local' hostnames. This works both for `ko` and our own tag-to-digest resolution logic,
+  # thus allowing us to test without bypassing tag-to-digest resolution.
+  KIND_VERSION: 0.12.0
+  KNATIVE_VERSION: 1.5.0
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go 1.17.x
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.17.x
+
+    - name: Build quickstart plugin
+      run: |
+        set -x
+        ./hack/build.sh
+        sudo mv kn-quickstart /usr/local/bin
+
+    - name: Install Dependencies
+      run: |
+        set -x
+        echo "::group:: install kind ${KIND_VERSION}"
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+        echo "::endgroup::"
+
+        echo "::group:: install kn client ${KNATIVE_VERSION}"
+        curl -Lo ./kn https://github.com/knative/client/releases/download/knative-v${KNATIVE_VERSION}/kn-linux-amd64
+        chmod +x ./kn
+        sudo mv kn /usr/local/bin
+        echo "::endgroup::"
+
+    - name: Serving e2e Test
+      run: |
+        kn quickstart kind --install-serving
+        source ./vendor/knative.dev/hack/e2e-tests.sh
+        ./test/serving-e2e-test.sh || fail_test
+
+    - uses: chainguard-dev/actions/kind-diag@main
+      # Only upload logs on failure.
+      if: ${{ failure() }}
+      with:
+        cluster-resources: nodes,${{ matrix.cluster-resources || '' }}
+        namespace-resources: pods,svc,ksvc,route,configuration,revision,king,${{ matrix.namespace-resources || '' }}
+        artifact-name: logs-${{ matrix.k8s-version}}-${{ matrix.ingress }}-${{ matrix.test-suite }}

--- a/test/eventing-e2e-test.sh
+++ b/test/eventing-e2e-test.sh
@@ -16,14 +16,6 @@
 
 set -euo pipefail
 
-# Serving Test
-echo "creating ksvc"
-kn service create hello --image gcr.io/knative-samples/helloworld-go --port 8080 --env TARGET=World --revision-name=world
-SERVICE=$(kn service describe hello -o url)
-
-echo "curling ksvc 'hello'"
-curl "$SERVICE"
-
 # Eventing Tests
 kn broker list
 echo "creating cloudevents player"
@@ -41,4 +33,4 @@ kn trigger create cloudevents-trigger --sink cloudevents-player  --broker exampl
 echo "posting trigger event"
 curl -v "$PLAYER"   -H "Content-Type: application/json"   -H "Ce-Id: foo-1"   -H "Ce-Specversion: 1.0"   -H "Ce-Type: dev.example.trigger"   -H "Ce-Source: curl-source"   -d '{"msg":"Hello team!"}'
 
-echo "minikube test finished"
+echo "test finished!"

--- a/test/serving-e2e-test.sh
+++ b/test/serving-e2e-test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Serving Test
+echo "creating ksvc"
+kn service create hello --image gcr.io/knative-samples/helloworld-go --port 8080 --env TARGET=World --revision-name=world
+SERVICE=$(kn service describe hello -o url)
+
+echo "curling ksvc 'hello'"
+curl "$SERVICE"
+
+echo "test finished!"


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Fixes #106 

Note: given the resource limitations of Github Actions, we'll need to split the e2e tests into one for serving and one for eventing. For eventing, we'll need to tweak the resources used by serving so as to be able to get under 2 vCPUs...