### PR TITLE
Adds flags for installing knative a la carte

### DIFF
--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -22,6 +22,8 @@ import (
 
 var name string
 var kubernetesVersion string
+var installServing bool
+var installEventing bool
 
 func clusterNameOption(targetCmd *cobra.Command, flagDefault string) {
 	targetCmd.Flags().StringVarP(
@@ -40,4 +42,12 @@ func kubernetesVersionOption(targetCmd *cobra.Command, flagDefault string, usage
 		"k",
 		flagDefault,
 		usageText)
+}
+
+func installServingOption(targetCmd *cobra.Command) {
+	targetCmd.Flags().BoolVar(&installServing, "install-serving", false, "install Serving on quickstart cluster")
+}
+
+func installEventingOption(targetCmd *cobra.Command) {
+	targetCmd.Flags().BoolVar(&installEventing, "install-eventing", false, "install Eventing on quickstart cluster")
 }

--- a/internal/command/kind.go
+++ b/internal/command/kind.go
@@ -28,12 +28,14 @@ func NewKindCommand() *cobra.Command {
 		Short: "Quickstart with Kind",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Kind")
-			return kind.SetUp(name, kubernetesVersion)
+			return kind.SetUp(name, kubernetesVersion, installServing, installEventing)
 		},
 	}
 	// Set kindCmd options
 	clusterNameOption(kindCmd, "knative")
 	kubernetesVersionOption(kindCmd, "", "kubernetes version to use (1.x.y) or (kindest/node:v1.x.y)")
+	installServingOption(kindCmd)
+	installEventingOption(kindCmd)
 
 	return kindCmd
 }

--- a/internal/command/minikube.go
+++ b/internal/command/minikube.go
@@ -30,11 +30,13 @@ func NewMinikubeCommand() *cobra.Command {
 		Short: "Quickstart with Minikube",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Minikube")
-			return minikube.SetUp(name, kubernetesVersion)
+			return minikube.SetUp(name, kubernetesVersion, installServing, installEventing)
 		},
 	}
 	// Set minikubeCmd options
 	clusterNameOption(minikubeCmd, "knative")
 	kubernetesVersionOption(minikubeCmd, "", "kubernetes version to use (1.x.y)")
+	installServingOption(minikubeCmd)
+	installEventingOption(minikubeCmd)
 	return minikubeCmd
 }


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

# Changes

Adds command line flags `--install-serving` and `install-eventing` to
enable users to install only one Knative component (i.e. only serving).
Using both flags will install both components (which is also the default
behavior when no flag is passed).

Fixes #224 
**Release Note**

```release-note
Adds command line flags to let users specify which Knative component(s) they want to install. For example, `kn quickstart kind --install-serving` would create a Kind quickstart cluster with only Knative Serving installed. No flag is required, and `kn quickstart minikube` would install both Serving and Eventing, as is currently done. 
```

