### PR TITLE
Require manual minikube tunnel on linux too

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -17,7 +17,6 @@ package install
 import (
 	"fmt"
 	"os/exec"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -103,17 +102,6 @@ func KourierMinikube() error {
 	}
 
 	fmt.Println("    Domain DNS set up...")
-
-	// For windows and mac users, do not automatically spawn a tunnel
-	// Instead, they will be directed to create one manually after
-	// the plugin finishes
-	if runtime.GOOS != "window" && runtime.GOOS != "darwin" {
-		tunnel := exec.Command("minikube", "tunnel", "--profile", "knative")
-		if err := tunnel.Start(); err != nil {
-			return fmt.Errorf("tunnel: %w", err)
-		}
-		fmt.Println("    Minikube tunnel...")
-	}
 
 	fmt.Println("    Finished configuring Kourier")
 	return nil

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -61,14 +60,12 @@ func SetUp(name, kVersion string, installServing, installEventing bool) error {
 	if err := createMinikubeCluster(); err != nil {
 		return fmt.Errorf("creating cluster: %w", err)
 	}
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-		fmt.Print("\n")
-		fmt.Println("To finish setting up networking for minikube, run the following command in a separate terminal window:")
-		fmt.Println("    minikube tunnel --profile knative")
-		fmt.Println("The tunnel command must be running in a terminal window any time when using the knative quickstart environment.")
-		fmt.Println("\nPress the Enter key to continue")
-		fmt.Scanln()
-	}
+	fmt.Print("\n")
+	fmt.Println("To finish setting up networking for minikube, run the following command in a separate terminal window:")
+	fmt.Println("    minikube tunnel --profile knative")
+	fmt.Println("The tunnel command must be running in a terminal window any time when using the knative quickstart environment.")
+	fmt.Println("\nPress the Enter key to continue")
+	fmt.Scanln()
 
 	if installServing {
 		if err := install.Serving(); err != nil {


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

<!-- Thanks for sending a pull request! -->

# Changes

Based on a [slack discussion](https://knative.slack.com/archives/C93E33SN8/p1654794336212679), the auto-tunnel for Linux users was causing problems, so this PR adds the pause & request a tunnel for Linux users too (we were already doing it for Mac and Windows users). 

```release-note
Linux users will need to manually create a tunnel for minikube. This should eliminate some common networking bugs and is already being done for Mac and Windows users.
```

/assign @csantanapr 

