### PR TITLE
Updates kubernetes version to v1.24.3

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -12,8 +12,8 @@ env:
   # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for
   # '*.local' hostnames. This works both for `ko` and our own tag-to-digest resolution logic,
   # thus allowing us to test without bypassing tag-to-digest resolution.
-  KIND_VERSION: 0.12.0
-  KNATIVE_VERSION: 1.5.0
+  KIND_VERSION: 0.14.0
+  KNATIVE_VERSION: 1.6.0
 
 jobs:
   build:
@@ -22,10 +22,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Go 1.17.x
+    - name: Set up Go 1.18.x
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
 
     - name: Build quickstart plugin
       run: |

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -26,9 +26,9 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
-var kubernetesVersion = "kindest/node:v1.23.3"
+var kubernetesVersion = "kindest/node:v1.24.3"
 var clusterName string
-var kindVersion = 0.11
+var kindVersion = 0.14
 
 // SetUp creates a local Kind cluster and installs all the relevant Knative components
 func SetUp(name, kVersion string, installServing, installEventing bool) error {

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -27,9 +27,9 @@ import (
 )
 
 var clusterName string
-var kubernetesVersion = "1.23.4"
+var kubernetesVersion = "1.24.3"
 var clusterVersionOverride bool
-var minikubeVersion = 1.25
+var minikubeVersion = 1.26
 var cpus = "3"
 var memory = "3072"
 
@@ -118,7 +118,7 @@ func checkMinikubeVersion() error {
 	}
 	if userMinikubeVersion < minikubeVersion {
 		var resp string
-		fmt.Printf("WARNING: We require at least Minikube v%.2f, while you are using v%.2f\n", minikubeVersion, userMinikubeVersion)
+		fmt.Printf("WARNING: We recommend at least Minikube v%.2f, while you are using v%.2f\n", minikubeVersion, userMinikubeVersion)
 		fmt.Println("You can download a newer version from https://github.com/kubernetes/minikube/releases/")
 		fmt.Print("Continue anyway? (not recommended) [y/N]: ")
 		fmt.Scanf("%s", &resp)


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>


# Changes

- Updates Kubernetes version to v1.24.3
- Bumps minikube / kind versions to latest

Fixes #286 

**Release Note**

```release-note
Updates Kubernetes to version v1.24.3. Updates minikube to v1.26. Updates kind to v0.14 (required for k8s v1.24+).
```

@knative-sandbox/client-writers 