### PR TITLE
Update knative versions to v1.7

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -21,9 +21,9 @@ import (
 	"time"
 )
 
-var servingVersion = "1.6.0"
-var kourierVersion = "1.6.0"
-var eventingVersion = "1.6.0"
+var servingVersion = "1.7.1"
+var kourierVersion = "1.7.0"
+var eventingVersion = "1.7.1"
 
 // Kourier installs Kourier networking layer from Github YAML files
 func Kourier() error {


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

# Changes

- Updates Knative componenets: 
    - Serving: v1.7.1
    - Eventing: v1.7.1
    - Kourier: v1.7.0

**Release Note**

```release-note
Updates quickstart to use Knative v1.7 components
```
