### PR TITLE
Fix cut command in build-flags script

### DIFF
--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -25,7 +25,7 @@ function build_flags() {
     version="v$(date +%Y%m%d)-local-${commit}"
   fi
   # Knative component versions
-  local branch="`git branch --show-current | cut -d '-' f2`"
+  local branch="`git branch --show-current | cut -d '-' -s -f2`"
   local serving="`git ls-remote --tags --ref https://github.com/knative/serving.git | grep -F "${branch}" | cut -d '-' -f2 | cut -d 'v' -f2 | sort -Vr | head -n 1`"
   local kourier="`git ls-remote --tags --ref https://github.com/knative-sandbox/net-kourier.git | grep -F "${branch}" | cut -d '-' -f2 | cut -d 'v' -f2 | sort -Vr | head -n 1`"
   local eventing="`git ls-remote --tags --ref https://github.com/knative/eventing.git | grep -F "${branch}" | cut -d '-' -f2 | cut -d 'v' -f2 | sort -Vr | head -n 1`"


### PR DESCRIPTION
# Changes

This PR fixes the parsing of the current git branch in the `build-flags.sh` script.

The current script is missing a `-` sign in `cut -d '-' f2`. As a result `branch` is always the empty string.

The proposed fix `cut -d '-' -s -f2` ensures not only that `1.7` is returned for branch `release-1.7` but also that the empty string is returned for branch `main` making it possible to grab the most recent releases in this case.

/kind enhancement
