### PR TITLE
Make kind local registry optional

### DIFF
--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -24,6 +24,7 @@ var name string
 var kubernetesVersion string
 var installServing bool
 var installEventing bool
+var installKindRegistry bool
 
 func clusterNameOption(targetCmd *cobra.Command, flagDefault string) {
 	targetCmd.Flags().StringVarP(
@@ -50,4 +51,8 @@ func installServingOption(targetCmd *cobra.Command) {
 
 func installEventingOption(targetCmd *cobra.Command) {
 	targetCmd.Flags().BoolVar(&installEventing, "install-eventing", false, "install Eventing on quickstart cluster")
+}
+
+func installKindRegistryOption(targetCmd *cobra.Command) {
+	targetCmd.Flags().BoolVar(&installKindRegistry, "registry", false, "install registry for kind quickstart cluster")
 }

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -54,5 +54,5 @@ func installEventingOption(targetCmd *cobra.Command) {
 }
 
 func installKindRegistryOption(targetCmd *cobra.Command) {
-	targetCmd.Flags().BoolVar(&installKindRegistry, "registry", false, "install registry for kind quickstart cluster")
+	targetCmd.Flags().BoolVar(&installKindRegistry, "registry", false, "install registry for Kind quickstart cluster")
 }

--- a/internal/command/kind.go
+++ b/internal/command/kind.go
@@ -28,7 +28,7 @@ func NewKindCommand() *cobra.Command {
 		Short: "Quickstart with Kind",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Kind")
-			return kind.SetUp(name, kubernetesVersion, installServing, installEventing)
+			return kind.SetUp(name, kubernetesVersion, installServing, installEventing, installKindRegistry)
 		},
 	}
 	// Set kindCmd options
@@ -36,6 +36,7 @@ func NewKindCommand() *cobra.Command {
 	kubernetesVersionOption(kindCmd, "", "kubernetes version to use (1.x.y) or (kindest/node:v1.x.y)")
 	installServingOption(kindCmd)
 	installEventingOption(kindCmd)
+	installKindRegistryOption(kindCmd)
 
 	return kindCmd
 }

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -102,6 +102,11 @@ func createKindCluster(registry bool) error {
 		if err := createLocalRegistry(); err != nil {
 			return fmt.Errorf("%w", err)
 		}
+	} else {
+		// temporary warning that registry creation is now opt-in
+		// remove in v1.12
+		fmt.Println("\nA local registry is no longer created by default.")
+		fmt.Println("    To create a local registry, use the --registry flag.")
 	}
 
 	if err := checkForExistingCluster(); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Fixes #393 

Installing a local registry causes problems for podman users. This PR makes the local registry opt-in by passing a `--registry` flag.

Also bumps the Kubernetes version to v1.26.6.

**Release Note**

```release-note
For Kind, a local registry will no longer be created by default. Users will need to pass the `--registry` flag if they wish to create a local registry.
```

